### PR TITLE
fix assertion after geoip database change

### DIFF
--- a/test/test.lua
+++ b/test/test.lua
@@ -194,7 +194,7 @@ do
   assert(res.code == "FR")
 
   res = geodb_country6:query_by_addr6("2a03:2880:f127:83:face:b00c:0:25de")
-  assert(res.code == "IE")
+  assert(res.code == "US")
   geodb_country6:close()
 end
 


### PR DESCRIPTION
The address 2a03:2880:f127:83:face:b00c:0:25de moved from IE to US in the geoip database.